### PR TITLE
WIP: Support building in `no_std` environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,28 @@ futures-await-await-macro = { path = "futures-await-await-macro", version = "0.2
 futures = "0.2.0-alpha"
 futures-stable = "0.2.0-alpha"
 pin-api = "0.1.1"
+
+[features]
+std = ["futures/std", "futures-stable/std", "pin-api/std"]
+default = ["std"]
+
+# Required patch to actually build `futures-executor` on targets that don't
+# provide a `std` crate
+#
+# https://github.com/rust-lang-nursery/futures-rs/commit/7010da42123149c1ec5a00763df2a6cac33d9b4f
+#
+# Would just patch `futures-executor`, but unfortunately that then depends on
+# the git built copies of `futures-core` etc. instead of the ones from
+# crates.io, so have to patch the entire `futures` tree.
+#
+# Then, because `futures-stable` individually depends on `futures-core` and
+# `futures-executor` instead of the facade, need to patch them as well.
+[patch.crates-io.futures]
+git = "https://github.com/rust-lang-nursery/futures-rs"
+branch = "master"
+[patch.crates-io.futures-core]
+git = "https://github.com/rust-lang-nursery/futures-rs"
+branch = "master"
+[patch.crates-io.futures-executor]
+git = "https://github.com/rust-lang-nursery/futures-rs"
+branch = "master"

--- a/futures-await-async-macro/src/lib.rs
+++ b/futures-await-async-macro/src/lib.rs
@@ -530,8 +530,8 @@ impl Fold for ExpandAsyncFor {
                     match r? {
                         ::futures::__rt::Async::Ready(e) => {
                             match e {
-                                ::futures::__rt::std::option::Option::Some(e) => e,
-                                ::futures::__rt::std::option::Option::None => break,
+                                ::futures::__rt::core::option::Option::Some(e) => e,
+                                ::futures::__rt::core::option::Option::None => break,
                             }
                         }
                         ::futures::__rt::Async::Pending => {

--- a/futures-await-await-macro/src/lib.rs
+++ b/futures-await-await-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// Ye Olde Await Macro
 ///
 /// Basically a translation of polling to yielding. This crate's macro is
@@ -20,12 +22,12 @@ macro_rules! await {
                 ::futures::__rt::in_ctx(|ctx| ::futures::__rt::StableFuture::poll(pin, ctx))
             };
             match poll {
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
-                    break ::futures::__rt::std::result::Result::Ok(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
+                    break ::futures::__rt::core::result::Result::Ok(e)
                 }
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Pending) => {}
-                ::futures::__rt::std::result::Result::Err(e) => {
-                    break ::futures::__rt::std::result::Result::Err(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Pending) => {}
+                ::futures::__rt::core::result::Result::Err(e) => {
+                    break ::futures::__rt::core::result::Result::Err(e)
                 }
             }
             yield ::futures::__rt::Async::Pending
@@ -44,12 +46,12 @@ macro_rules! await_item {
         loop {
             let poll = ::futures::__rt::in_ctx(|ctx| ::futures::Stream::poll_next(&mut $e, ctx));
             match poll {
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
-                    break ::futures::__rt::std::result::Result::Ok(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Ready(e)) => {
+                    break ::futures::__rt::core::result::Result::Ok(e)
                 }
-                ::futures::__rt::std::result::Result::Ok(::futures::__rt::Async::Pending) => {}
-                ::futures::__rt::std::result::Result::Err(e) => {
-                    break ::futures::__rt::std::result::Result::Err(e)
+                ::futures::__rt::core::result::Result::Ok(::futures::__rt::Async::Pending) => {}
+                ::futures::__rt::core::result::Result::Err(e) => {
+                    break ::futures::__rt::core::result::Result::Err(e)
                 }
             }
 

--- a/src/__rt/future.rs
+++ b/src/__rt/future.rs
@@ -1,4 +1,4 @@
-use std::ops::{Generator, GeneratorState};
+use core::ops::{Generator, GeneratorState};
 
 use super::{IsResult, Reset, CTX};
 

--- a/src/__rt/mod.rs
+++ b/src/__rt/mod.rs
@@ -2,9 +2,10 @@ mod future;
 mod stream;
 mod pinned_future; mod pinned_stream;
 
-use std::cell::Cell;
-use std::mem;
-use std::ptr;
+use core::cell::Cell;
+use core::mem;
+use core::ptr;
+use core::result::Result;
 use futures::task;
 
 pub use self::future::*;
@@ -15,10 +16,12 @@ pub use self::pinned_stream::*;
 pub use futures::prelude::{Async, Future, Stream};
 pub use stable::{StableFuture, StableStream};
 
+pub extern crate core;
+#[cfg(feature = "std")]
 pub extern crate std;
 pub extern crate pin_api;
 
-pub use std::ops::Generator;
+pub use core::ops::Generator;
 
 #[rustc_on_unimplemented = "async functions must return a `Result` or \
                             a typedef of `Result`"]
@@ -39,7 +42,25 @@ pub fn diverge<T>() -> T { loop {} }
 
 type StaticContext = *mut task::Context<'static>;
 
+#[cfg(feature = "std")]
 thread_local!(static CTX: Cell<StaticContext> = Cell::new(ptr::null_mut()));
+
+#[cfg(not(feature = "std"))]
+pub struct NonLocalKey<T: 'static>(T);
+
+#[cfg(not(feature = "std"))]
+impl<T: 'static> NonLocalKey<T> {
+    pub fn with<F, R>(&'static self, f: F) -> R where F: FnOnce(&T) -> R {
+        f(&self.0)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+// Very definitely not safe...
+unsafe impl<T: 'static> Sync for NonLocalKey<T> {}
+
+#[cfg(not(feature = "std"))]
+pub static CTX: NonLocalKey<Cell<StaticContext>> = NonLocalKey(Cell::new(ptr::null_mut()));
 
 struct Reset<'a>(StaticContext, &'a Cell<StaticContext>);
 

--- a/src/__rt/pinned_future.rs
+++ b/src/__rt/pinned_future.rs
@@ -1,4 +1,4 @@
-use std::ops::{Generator, GeneratorState};
+use core::ops::{Generator, GeneratorState};
 
 use __rt::pin_api::{PinMut, Unpin};
 

--- a/src/__rt/pinned_stream.rs
+++ b/src/__rt/pinned_stream.rs
@@ -1,5 +1,5 @@
-use std::ops::{Generator, GeneratorState};
-use std::marker::PhantomData;
+use core::ops::{Generator, GeneratorState};
+use core::marker::PhantomData;
 
 use __rt::pin_api::{PinMut, Unpin};
 use futures::task;

--- a/src/__rt/stream.rs
+++ b/src/__rt/stream.rs
@@ -1,5 +1,5 @@
-use std::ops::{Generator, GeneratorState};
-use std::marker::PhantomData;
+use core::ops::{Generator, GeneratorState};
+use core::marker::PhantomData;
 
 use futures::task;
 use futures::prelude::{Poll, Async, Stream};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,18 @@
 //!
 //! See the crates's README for more information about usage.
 
+#![no_std]
+
 #![feature(conservative_impl_trait)]
 #![feature(generator_trait)]
 #![feature(use_extern_macros)]
 #![feature(on_unimplemented)]
 #![feature(arbitrary_self_types)]
 #![feature(optin_builtin_traits)]
+
+#[cfg(feature = "std")]
+#[macro_use]
+extern crate std;
 
 extern crate futures_await_async_macro as async_macro;
 extern crate futures_await_await_macro as await_macro;


### PR DESCRIPTION
Depends on https://github.com/withoutboats/futures-stable/pull/1.

I'm really hoping there's a better way to do the `task::Context` passing. This works fine with my usecase since I'm running interruptless on a single threaded micro-controller, but I can definitely imagine some `no_std` usecases where this using a global could cause issues.